### PR TITLE
Ignore JCasC test on Windows

### DIFF
--- a/src/test/java/hudson/security/PAMSecurityRealmJCasCTest.java
+++ b/src/test/java/hudson/security/PAMSecurityRealmJCasCTest.java
@@ -1,18 +1,26 @@
 package hudson.security;
 
+import hudson.Functions;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assume.assumeFalse;
 
 public class PAMSecurityRealmJCasCTest {
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @BeforeClass
+    public static void beforeEverythingAssumeWindows() {
+        assumeFalse(Functions.isWindows());
+    }
 
     @Test
     @ConfiguredWithCode("config.yaml")


### PR DESCRIPTION
To solve the CI failures in https://github.com/jenkinsci/pam-auth-plugin/pull/19